### PR TITLE
feat(api): change update endpoint to use PATCH HTTP method

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -119,7 +119,7 @@ router.get(
   }
 )
 
-router.post(
+router.patch(
   "/event/update/:eventId",
   isAuthenticated,
   async (


### PR DESCRIPTION
Pra seguir as convenções do padrão rest troquei o verbo http post pra patch já que se trata da atualização dos dados